### PR TITLE
Update version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack-in-card",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Stack in Card for Home Assistant's Lovelace UI",
   "main": "dist/stack-in-card.js",
   "pre-commit": [


### PR DESCRIPTION
Hi,

I tried using your fork instead of the original card, but I have no idea if it worked or not because the version displayed in the JavaScript console is `0.2.0`

![image](https://user-images.githubusercontent.com/17952318/222064754-c3c12b5c-47d6-472e-a603-967ac39537dc.png)

This is the responsible code: https://github.com/ov1d1u/stack-in-card/blob/26972f8981ccdbba4104a746102f55a4b160430a/src/stack-in-card.ts#L5-L11

I suggest you bump the version so users know if they use the forked version or the original one
